### PR TITLE
Add cml to build native codes without sandbox

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,8 @@
       let nixflow = import ./nix/nixflow.nix {pkgs=pkgs-locked;};
           pkgs = import nixpkgs {inherit system;};
           pkgs-locked = import nixpkgs-locked {inherit system;};
-          cml = import ./utils/cml/default.nix {inherit pkgs;};
+#          cml = import ./utils/cml/default.nix {inherit pkgs;};
+          cml = import ./utils/cml/non-sandbox.nix {inherit pkgs;};
           huggingface = import ./models/huggingface/default.nix {inherit pkgs;};
           
           torchvision = import ./models/torchvision/default.nix {inherit pkgs;};

--- a/utils/cml/non-sandbox.nix
+++ b/utils/cml/non-sandbox.nix
@@ -3,7 +3,7 @@
 with pkgs;
 stdenv.mkDerivation {
   pname = "cml";
-  version = "2018-11-16";
+  version = "0.7.6";
   src = fetchFromGitHub {
     owner = "iterative";
     repo = "cml";

--- a/utils/cml/non-sandbox.nix
+++ b/utils/cml/non-sandbox.nix
@@ -1,0 +1,30 @@
+{pkgs
+}:
+with pkgs;
+stdenv.mkDerivation {
+  pname = "cml";
+  version = "2018-11-16";
+  src = fetchFromGitHub {
+    owner = "iterative";
+    repo = "cml";
+    rev = "47b3ed6a4dfa847139f0da337ff40f7360a7b255";
+    # nix-prefetch-url --unpack https://github.com/iterative/cml/archive/47b3ed6a4dfa847139f0da337ff40f7360a7b255.tar.gz
+    sha256 = "0glvpk3b58ij11mxxza355mbzv14s1jfrksqw9cl020aav73g7wc";
+  };
+  nativeBuildInputs = [ nodePackages.npm nodejs python39 makeWrapper ];
+  installPhase = ''
+    ls > list
+    export HOME=`pwd`
+    mkdir -p $out/build/cml $out/bin
+    cp -r `cat list` $out/build/cml
+    touch .npmrc
+    pushd $out/build/cml
+    rm package-lock.json
+    npm install
+    sed -i -e 's|/usr/bin/env node|${nodejs}/bin/node|g' $out/build/cml/bin/cml.js
+    makeWrapper $out/build/cml/bin/cml.js $out/bin/cml --set NODE_PATH $out/build/cml/node_modules
+    popd
+  '';
+  #phases = [ "installPhase" ];
+}
+


### PR DESCRIPTION
To use cml with mmmagic using native code, add cml without sandbox environment.
https://github.com/hasktorch/hasktorch-datasets/issues/35

The build command is as follows.

```
nix build .#cml --option sandbox false
```